### PR TITLE
remove unnecessary Clone bounds

### DIFF
--- a/src/genetic.rs
+++ b/src/genetic.rs
@@ -102,7 +102,7 @@ pub trait AsScalar {
 
 /// Defines the evaluation function to calculate the `Fitness` value of a
 /// `Genotype` based on its properties.
-pub trait FitnessFunction<G, F>: Clone
+pub trait FitnessFunction<G, F>
 where
     G: Genotype,
     F: Fitness,

--- a/src/operator/mod.rs
+++ b/src/operator/mod.rs
@@ -31,7 +31,7 @@ pub trait MultiObjective {}
 /// There are unary operators that operate on one genotype at a time, e.g.
 /// mutation operators, and binary operators that work on two genotypes
 /// at a time, e.g. crossover operators.
-pub trait GeneticOperator: Clone {
+pub trait GeneticOperator {
     /// The name of the operator used for display purposes. The name should
     /// make clear to the user of the simulation which implementation of which
     /// kind of operator is being performed.

--- a/src/reinsertion/elitist.rs
+++ b/src/reinsertion/elitist.rs
@@ -26,7 +26,7 @@ use std::marker::PhantomData;
 /// individuals then the new population is filled up with individuals from the
 /// old population. If the offspring contains more individuals than the size of
 /// the population then the individuals are chosen uniformly at random.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct ElitistReinserter<G, F, E>
 where
     G: Genotype,

--- a/src/reinsertion/elitist.rs
+++ b/src/reinsertion/elitist.rs
@@ -21,7 +21,7 @@ use std::marker::PhantomData;
 /// individuals from the offspring. The remaining spots are filled with
 /// individuals from the old population.
 ///
-/// A replace ratio of 1.0 means that the new population is fist filled with
+/// A replace ratio of 1.0 means that the new population is first filled with
 /// individuals from the offspring. If the offspring does not contain enough
 /// individuals then the new population is filled up with individuals from the
 /// old population. If the offspring contains more individuals than the size of


### PR DESCRIPTION
I happened to have some structures that were not `Clone`.  `genevo` does not actually require these bounds - as proved by simply removing them.  So no need to impose them.